### PR TITLE
Add whitelist feature, fix bug, add type hints and improve documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ metadata.json
 trait_usage_statistics.json
 traits.json
 traits_info.xlsx
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,28 +13,86 @@ _I'm not a developer, but I enjoy creating tools that might simplify life for ot
 - **Statistics and Summary**: Offers a breakdown of trait usage throughout the collection, with distribution and occurrence frequency of each trait. It's crucial to personally verify that the output aligns with your expectations, as the script doesn't guarantee absolute accuracy.
 
 ### Requirements
-- Python 3.x
+- Python 3.12 or higher
 - The `openpyxl` library, essential for managing Excel spreadsheets.
 
 ### How to Use
 1. **Setting Up Your Environment**:
-   - Confirm that Python 3 is installed on your system.
+   - Confirm that Python 3.12 is installed on your system. To check the version run `python --version`. Python can be installed from here: [https://www.python.org/downloads/](https://www.python.org/downloads/)
    - Install the required `openpyxl` library using the command: `pip install openpyxl`.
 
 2. **Configuration**:
-   - Specify the `ROOT_DIRECTORY` within the script (default set as 'traits'). This directory should host subdirectories, each symbolizing a different trait type, with individual files within these subfolders representing the traits.
+   - All the images of your traits should be placed in a folder called `traits` that is in the current working 
+     directory. If you put your traits in a different directory, you can set the `ROOT_DIRECTORY` variable within the 
+     script.
+   - This directory should have several folders within it, with each folder representing a trait type 
+     (e.g. Background, Head, Expression, etc.). The images of each trait are placed within these trait type directories.
+   - The trait type folders must be prepended with a number, which indicates the layering order of the images. 
+     For example, a folder with the name `2. Body` represents a trait type called `Body` which is second in the 
+     layering order of the trait images. `1` is the furthest back trait (i.e. the background), and increasing numbers 
+     are layered on top of lower numbers. Below is an example folder structure for a project with 4 trait types. 
+    ```
+    traits
+    ├─ 1. Background
+    │  ├─ Yellow.webp
+    │  ├─ Blue.webp
+    │  ├─ Mint.webp
+    │  └─ Pink.webp
+    ├─ 2. Body
+    │  ├─ Wizard Robes.webp
+    │  ├─ Cargo Jacket.webp
+    │  ├─ Collared Shirt.webp
+    │  └─ Hoodie.webp
+    ├─ 3. Head
+    │  ├─ Slate.webp
+    │  ├─ Yellow.webp
+    │  └─ Grey.webp
+    └─ 4. Expression
+       ├─ Cheeky.webp
+       ├─ Blindfold.webp
+       ├─ Hearts.webp
+       ├─ Glasses.webp
+       ├─ Shades.webp
+       └─ Crying.webp
+    ```
 
 3. **Running the Script**:
    - Initiate the script by executing `python generateorder.py` in your terminal.
-   - The script kickstarts the process by creating a 'traits_info.xlsx' spreadsheet based on your folder structure.
-   - Leaving the rarity field empty defaults to a random rarity assignment.
-   - If opting for specific rarity percentages, ensure the collective rarity across all traits within a type equals 100%.
-   - To prevent certain traits from pairing in the generated metadata, list the trait numbers in the 'Avoid Traits' column, separating multiple traits with commas.
+   - The script will create a 'traits_info.xlsx' spreadsheet based on your folder structure. This spreadsheet is used 
+     to configure how your collection is generated. Everything in the spreadsheet is optional, so you can run the 
+     script without adding anything to the spreadsheet, but you will likely want to add rules and rarity to get it to 
+     generate the way you want. The following options are available in the spreadsheet
+     - `Rarity (%)`: This is how frequently each trait will be generated as a percentage (i.e. a number from 0 to 100).
+        The rarity of all traits within a given trait type should add to 100. If no rarities are given, then all traits 
+        are used with equal probability
+     - `Blacklist`: This can be used to blacklist certain trait combinations. If you have two traits that don't work well
+       together, then you can add a blacklist to them, which means they will never generate together. The blacklist is
+       a comma separated list of numbers of the traits to blacklist, where the numbers are obtained from the first 
+       column (`Number`). For example, lets say you have two traits `Shades` and `Glasses` that don't work when 
+       combined with a `Hoodie`. Then look up the numbers assigned to `Shades` and `Glasses` in the first column. If 
+       they have numbers 15 and 16, then you would put `15, 16` in the `Blacklist` column for the `Hoodie` trait. 
+       NOTE: You could also do the reverse and put the number for `Hoodie` in both the `Glasses` and `Shades` rows to 
+       achieve the same outcome
+     - `Whitelist`: The whitelist has the same format as the `Blacklist`, and is the opposite of a blacklist. If you 
+       whitelist certain traits, then it means that trait will *only* generate with it's whitelisted traits. This is 
+       very useful to 'link' together two images that represent the same trait. For example, if you have a hair trait 
+       type, but to get the layering to work you had to separate the images into a back and front, where the back image 
+       goes behind the head, and the front in front of the head, then you can use whitelists to make sure that each
+       back hair trait generates with its corresponding front hair trait
+     - `Inscription ID`: If your traits are already inscribed, you can put the inscription ID's for each one in here,
+       and the script will generate your `traits.json` file that can be uploaded to 
+       [GeneratOrd](https://www.generatord.io)
+   - You can delete, add and reorder traits, however, be careful when doing so. The `Number` column is used to 
+     associate the `Whitelist` and `Blacklist` columns to the traits, so if you change which numbers correspond to 
+     which trait, it may make all of your whitelists and blacklists incorrect
 
 4. **Generating Metadata**:
    - Once you've updated the 'traits_info.xlsx' file, press Enter in your terminal to prompt the script to continue.
    - Specify the quantity of items (inscriptions) for which you intend to generate metadata.
-   - The script then creates the metadata generation, ensuring each item is not the same as any other already created for metadata and attempts to abide by rarity and trait avoidence. It concurrently validates the data to identify any inconsistencies or breaks in the rules. It's IMPORTANT to double-check your metadata for precision, as discrepancies may exist.
+   - The script then creates the metadata generation, ensuring each item is not the same as any other already created 
+     for metadata and attempts to abide by rarity, blacklists and whitelists. It concurrently validates the data to 
+     identify any inconsistencies or breaks in the rules. It's IMPORTANT to double-check your metadata for precision, as
+     discrepancies may exist.
 
 5. **Output**:
    - Upon completion, the script generates several files:
@@ -43,9 +101,13 @@ _I'm not a developer, but I enjoy creating tools that might simplify life for ot
      - `trait_usage_statistics.json`: Presents a detailed account of trait usage and distribution throughout the collection.
 
 ### Handling Errors and Inconsistencies:
-- Should you encounter errors or inconsistencies within the 'traits_info.xlsx' file or the generated metadata, the script will highlight these. It's advisable to rectify these based on the provided feedback and re-run the script if necessary.
+- Should you encounter errors or inconsistencies within the 'traits_info.xlsx' file or the generated metadata, the 
+  script will highlight these. It's advisable to rectify these based on the provided feedback and re-run the script if 
+  necessary.
 
 ### Caution
-- It's important to ensure that the rules established for rarity and trait avoidance are logically sound. Conflicting or ambiguous rules could hinder the script's ability to produce the collection metadata.
+- It's important to ensure that the rules established for rarity and trait avoidance are logically sound. Conflicting 
+  or ambiguous rules could hinder the script's ability to produce the collection metadata.
 
-*In scenarios where the script struggles to generate unique metadata for each collection item, it's worthwhile to consider introducing additional traits or tweaking the rules to accommodate a broader range of unique combinations.*
+*In scenarios where the script struggles to generate unique metadata for each collection item, it's worthwhile to 
+consider introducing additional traits or tweaking the rules to accommodate a broader range of unique combinations.*

--- a/generatorder.py
+++ b/generatorder.py
@@ -4,6 +4,7 @@ import json
 import re
 import hashlib
 import time
+from typing import List, Set, Dict, Tuple
 
 from openpyxl import Workbook, load_workbook
 from dataclasses import dataclass
@@ -20,16 +21,16 @@ class TraitInfo:
     type: str
     name: str
     weight: float
-    blacklist: set[int]
-    whitelist: set[int]
+    blacklist: Set[int]
+    whitelist: Set[int]
 
     def __hash__(self):
         return hash((self.type, self.name))
 
 
-type TraitsInfo = dict[str, dict[str, TraitInfo]]
-type TraitsMapping = dict[int, TraitInfo]
-type FormattedInscription = list[dict[str, str]]
+TraitsInfo = Dict[str, Dict[str, TraitInfo]]
+TraitsMapping = Dict[int, TraitInfo]
+FormattedInscription = List[Dict[str, str]]
 
 
 # ======================== UTILITY FUNCTIONS ========================
@@ -50,7 +51,7 @@ def get_positive_integer(message: str) -> int:
 
 
 # ======================== SPREADSHEET MANAGEMENT ========================
-def create_spreadsheet(traits_dict: dict[str, list[str]]) -> None:
+def create_spreadsheet(traits_dict: Dict[str, List[str]]) -> None:
     workbook = Workbook()
     sheet = workbook.active
     sheet.title = "Traits Information"
@@ -86,7 +87,7 @@ def create_spreadsheet(traits_dict: dict[str, list[str]]) -> None:
           "Please fill in the required information in this file before proceeding.")
 
 
-def parse_int_set(comma_separated_list: str, error_name: str) -> set[int]:
+def parse_int_set(comma_separated_list: str, error_name: str) -> Set[int]:
     number_list = set()
     str_list = [x.strip() for x in comma_separated_list.split(',') if len(x.strip()) > 0]
 
@@ -118,14 +119,14 @@ def convert_whitelist_to_blacklist(traits: TraitsInfo, trait_mapping: TraitsMapp
                 whitelist = [x for x in whitelist if x not in whitelisted_traits]
 
 
-def load_traits_info() -> tuple[TraitsInfo, TraitsMapping]:
+def load_traits_info() -> Tuple[TraitsInfo, TraitsMapping]:
     workbook = load_workbook("traits_info.xlsx")
     sheet = workbook.active
 
     all_traits_info: TraitsInfo = {}
     trait_number_mapping: TraitsMapping = {}
     errors = []
-    cumulative_weights: dict[str, float] = {}
+    cumulative_weights: Dict[str, float] = {}
 
     # Determine the row with the headers (in case user deletes the top row that has the link)
     header_index = 1
@@ -214,7 +215,7 @@ def load_traits_info() -> tuple[TraitsInfo, TraitsMapping]:
 
 
 # ======================== VALIDATION FUNCTIONS ========================
-def validate_inscription_avoidance(inscription_collection: list[FormattedInscription], all_traits_info: TraitsInfo):
+def validate_inscription_avoidance(inscription_collection: List[FormattedInscription], all_traits_info: TraitsInfo):
     inconsistencies = []
 
     for inscription_index, inscription in enumerate(inscription_collection, start=1):
@@ -240,7 +241,7 @@ def validate_inscription_avoidance(inscription_collection: list[FormattedInscrip
     return inconsistencies
 
 
-def validate_traits(selected_traits: list[TraitInfo], trait_number_mapping: TraitsMapping):
+def validate_traits(selected_traits: List[TraitInfo], trait_number_mapping: TraitsMapping):
     for trait in selected_traits:
         for blacklist_number in trait.blacklist:
             blacklist_trait = trait_number_mapping[blacklist_number]
@@ -253,8 +254,8 @@ def validate_traits(selected_traits: list[TraitInfo], trait_number_mapping: Trai
 # ======================== METADATA GENERATION ========================
 def generate_inscriptions(
         all_traits_info: TraitsInfo, trait_number_mapping: TraitsMapping, num_inscriptions: int
-) -> tuple[list[FormattedInscription], dict, dict[int, int]]:
-    inscription_collection: list[FormattedInscription] = []
+) -> Tuple[List[FormattedInscription], Dict, Dict[int, int]]:
+    inscription_collection: List[FormattedInscription] = []
     traits_usage = {
         trait_type: {
             trait_name: {
@@ -276,9 +277,9 @@ def generate_inscriptions(
                 last_update_time = time.time()
                 print(f'Generated {len(inscription_collection)}/{num_inscriptions}')
 
-            inscription_traits: list[TraitInfo] = []
+            inscription_traits: List[TraitInfo] = []
             formatted_traits: FormattedInscription = []
-            current_avoid_list: list[int] = []
+            current_avoid_list: List[int] = []
 
             valid_combination = True
             for trait_group in all_traits_info.values():
@@ -290,7 +291,7 @@ def generate_inscriptions(
                     valid_combination = False
                     break
 
-                weights: list[float] = []
+                weights: List[float] = []
 
                 for trait in available_traits:
                     # Dynamic weight calculation. The weights are recalculated each time based on the current trait
@@ -374,7 +375,7 @@ def main():
     if not os.path.exists("traits_info.xlsx"):
         trait_types = sorted([x for x in os.listdir(ROOT_DIRECTORY) if os.path.isdir(os.path.join(ROOT_DIRECTORY, x))],
                              key=lambda x: (int(x.split('.')[0]), x.split('.')[1]))
-        traits_dict: dict[str, list[str]] = {}
+        traits_dict: Dict[str, List[str]] = {}
 
         for trait_type in trait_types:
             trait_type_name = trait_type.split('. ')[1]


### PR DESCRIPTION
- Rename 'Trait Avoidance' to blacklist, as it aligns better with the whitelist terminology introduced in this PR
- Add whitelist feature
  - Whitelist is the opposite of blacklist. If one trait is whitelisted with another then that trait can only generate with the other one.
  - This is implemented by converting the whitelist into a blacklist when the spreadsheet is loaded. For each trait type, if it has a whitelist, then all traits in the whitelisted trait type are blacklisted, except for the whitelisted trait. Then, the rest of the script essentially works the same with these additional blacklists (trait avoidance)
- Add type hints, making it easier to catch bugs
- Fix bug with `available_traits` being incorrectly computed. Blacklists (trait avoidances) where not properly being filtered out, which means a lot more inconsistent combinations where generated than should have been. Now this is fixed, the script is a lot faster, as it can choose only traits that agree with the blacklist, resulting in far fewer invalid generations
- Improve documentation