### PR TITLE
Fix bug related to integer parsing of the whitelist/blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ _I'm not a developer, but I enjoy creating tools that might simplify life for ot
 - **Statistics and Summary**: Offers a breakdown of trait usage throughout the collection, with distribution and occurrence frequency of each trait. It's crucial to personally verify that the output aligns with your expectations, as the script doesn't guarantee absolute accuracy.
 
 ### Requirements
-- Python 3.12 or higher
+- Python 3.8 or higher
 - The `openpyxl` library, essential for managing Excel spreadsheets.
 
 ### How to Use
 1. **Setting Up Your Environment**:
-   - Confirm that Python 3.12 is installed on your system. To check the version run `python --version`. Python can be installed from here: [https://www.python.org/downloads/](https://www.python.org/downloads/)
+   - Confirm that Python 3.8 or higher is installed on your system. To check the version run `python --version`. Python can be installed from here: [https://www.python.org/downloads/](https://www.python.org/downloads/)
    - Install the required `openpyxl` library using the command: `pip install openpyxl`.
 
 2. **Configuration**:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ### Overview
 This script serves as a convenient tool for generating metadata for collections, tailored for compatibility with www.generatord.io. It may not align with the requirements of other platforms. The script allows users to define trait rarities, specify traits that should not coexist, and even consider the absence of a trait ("none") as a valid option.
 
-_I'm not a developer, but I enjoy creating tools that might simplify life for others. A large portion of this script was created by ChatGPT. Me monkey, me type._
-
 ## Features
 - **Spreadsheet Creation**: Creates an organized spreadsheet that users can navigate with ease. This setup facilitates the adjustment of trait rarities and creates rules for trait compatibility.
 

--- a/generatorder.py
+++ b/generatorder.py
@@ -403,7 +403,12 @@ def main():
             print(f"- {inconsistency}")
 
     with open('metadata.json', 'w') as file:
-        json.dump(inscription_collection, file, indent=4)
+        json.dump([
+            {
+                "token id": f"#{i+1}",
+                "attributes": item
+            } for i, item in enumerate(inscription_collection)
+        ], file, indent=4)
 
     traits_inscription_mapping = {}
     for trait_type, traits in all_traits_info.items():

--- a/generatorder.py
+++ b/generatorder.py
@@ -93,7 +93,10 @@ def parse_int_set(comma_separated_list: str, error_name: str) -> Set[int]:
 
     for potential_number in str_list:
         try:
-            number_list.add(int(potential_number))
+            float_value = float(potential_number)
+            if not float_value.is_integer():
+                raise ValueError
+            number_list.add(int(float_value))
         except ValueError:
             raise Exception(
                 f"{error_name} contains invalid entry '{potential_number}'. Only whole numbers are allowed.")
@@ -194,11 +197,6 @@ def load_traits_info() -> Tuple[TraitsInfo, TraitsMapping]:
         all_traits_info[trait.type][trait.name] = trait
         trait_number_mapping[trait.number] = trait
 
-    # Normalise weights so they add to 1
-    for trait_type, total_weight in cumulative_weights.items():
-        for trait_name, trait_info in all_traits_info[trait_type].items():
-            trait_info.weight /= total_weight
-
     try:
         convert_whitelist_to_blacklist(all_traits_info, trait_number_mapping)
     except Exception as e:
@@ -210,6 +208,11 @@ def load_traits_info() -> Tuple[TraitsInfo, TraitsMapping]:
             print(error_message)
         print("\nPlease correct the errors in the spreadsheet and try again.")
         exit()
+
+    # Normalise weights so they add to 1
+    for trait_type, total_weight in cumulative_weights.items():
+        for trait_name, trait_info in all_traits_info[trait_type].items():
+            trait_info.weight /= total_weight
 
     return all_traits_info, trait_number_mapping
 


### PR DESCRIPTION
I did not realise that excel represents numbers as floats (i.e. '73.0'), so I introduced a bug in the last PR by removing the float parsing and integer checks in the blacklist parsing code.
Added back in this logic so it properly handles cases where excel puts a decimal point into an integer